### PR TITLE
Disable addon on secure screens

### DIFF
--- a/addon/globalPlugins/nao/__init__.py
+++ b/addon/globalPlugins/nao/__init__.py
@@ -8,6 +8,7 @@ import globalPluginHandler
 import addonHandler
 from scriptHandler import script
 from baseObject import ScriptableObject
+import globalVars
 
 from .nao_document_cache import NaoDocumentCache
 from .framework.ocr.ocr_helper import OCRHelper
@@ -52,6 +53,12 @@ class RecognizableFileObject(ScriptableObject):
 		else:
 			BrowseAndRecognize()
 
+def disableInSecure(cls):
+	if globalVars.appArgs.secure:
+		return globalPluginHandler.GlobalPlugin
+	return cls
+
+@disableInSecure
 class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 	def __init__(self):
 		from .nao_pickle import NaoPickle


### PR DESCRIPTION
Currently, the addon can be used on secure screens. This is a problem because you can access the file chooser.
My proposed solution is to just disable the addon entirely on secure screens, since OCR functionality isn't needed there.
