### PR TITLE
Recognize Outlook attachments

### DIFF
--- a/addon/globalPlugins/nao/__init__.py
+++ b/addon/globalPlugins/nao/__init__.py
@@ -9,6 +9,7 @@ import globalPluginHandler
 import addonHandler
 from scriptHandler import script
 from baseObject import ScriptableObject
+from logHandler import log
 
 from .nao_document_cache import NaoDocumentCache
 from .framework.ocr.ocr_helper import OCRHelper
@@ -47,11 +48,13 @@ class RecognizableFileObject(ScriptableObject):
 	def script_recognize_file(self, gesture):
 		if not globalVars.appArgs.secure:
 			try:
-				filename = explorer.get_selected_file()
+				filename, temp_path = explorer.get_selected_file()
 			except:
+				log.debugWarning(f"Cannot detect current file name.", exc_info=True)
 				filename = None
+				temp_path = None
 			if filename:
-				OCRHelper(ocr_document_file_extension=OCR_DOCUMENT_FILE_EXTENSION, ocr_document_file_cache=NaoDocumentCache()).recognize_file(filename)
+				OCRHelper(ocr_document_file_extension=OCR_DOCUMENT_FILE_EXTENSION, ocr_document_file_cache=NaoDocumentCache()).recognize_file(filename, temp_path=temp_path)
 			else:
 				BrowseAndRecognize()
 
@@ -80,6 +83,8 @@ class GlobalPlugin(globalPluginHandler.GlobalPlugin):
 			elif explorer.is_totalcommander(obj):
 				clsList.insert(0, RecognizableFileObject)
 			elif explorer.is_xplorer2(obj):
+				clsList.insert(0, RecognizableFileObject)
+			elif explorer.is_outlook(obj):
 				clsList.insert(0, RecognizableFileObject)
 
 	@script(

--- a/addon/globalPlugins/nao/framework/storage/explorer.py
+++ b/addon/globalPlugins/nao/framework/storage/explorer.py
@@ -10,6 +10,7 @@ import os
 from comtypes.client import CreateObject as COMCreate
 from .xplorer2Helper import Xplorer2Helper
 from .totalCommanderHelper import TotalCommanderHelper
+from .outlookHelper import OutlookHelper
 
 _shell = None
 
@@ -23,6 +24,9 @@ def is_totalcommander(obj=None):
 
 def is_xplorer2(obj=None):
 	return Xplorer2Helper.is_xplorer2(obj)
+
+def is_outlook(obj=None):
+	return OutlookHelper.is_outlook(obj)
 
 def get_selected_files_explorer_ps():
 	import subprocess
@@ -92,10 +96,19 @@ def get_selected_file_xplorer2(obj=None):
 		return xplorer2.currentFileWithPath()
 	return False
 
+def get_selected_file_outlook(obj=None):
+	# We check if we are in Outlook
+	outlook = OutlookHelper(obj)
+	if outlook.is_valid():
+		return outlook.currentFileWithPath()
+	return False
+
 def get_selected_file(obj=None):
 	file_path = False
+	temp_path = None
 	if obj is None: obj = api.getForegroundObject()
 	file_path = get_selected_file_explorer(obj)
 	if not file_path: file_path = get_selected_file_total_commander(obj)
 	if not file_path: file_path = get_selected_file_xplorer2(obj)
-	return file_path
+	if not file_path: file_path, temp_path = get_selected_file_outlook(obj)
+	return file_path, temp_path

--- a/addon/globalPlugins/nao/framework/storage/outlookHelper.py
+++ b/addon/globalPlugins/nao/framework/storage/outlookHelper.py
@@ -1,0 +1,60 @@
+#Nao (NVDA Advanced OCR) is an addon that improves the standard OCR capabilities that NVDA provides on modern Windows versions.
+#This file is covered by the GNU General Public License.
+#See the file COPYING for more details.
+#Last update 2024-12-02
+#Copyright (C) 2024 Alessandro Cyrille Bougot
+
+import os
+import tempfile
+import api
+from logHandler import log
+
+CONTROL_ID_ATTACHMENTS = 4306
+
+class OutlookHelper:
+	def is_outlook(obj=None):
+		if obj is None: obj = api.getForegroundObject()
+		return obj and obj.appModule and obj.appModule.appName and obj.appModule.appName == 'outlook'
+
+	def __init__(self, obj=None):
+		self.obj = obj
+		self.nativeOm = None
+		if OutlookHelper.is_outlook(obj):
+			self.nativeOm = obj.appModule.nativeOm
+
+	def is_valid(self):
+		return self.nativeOm != None
+
+	def is_active(self):
+		return self.handle and self.handle == ctypes.windll.user32.GetForegroundWindow()
+
+	def focusInAttachmentsList(self):
+		for o in reversed(api.getFocusAncestors()):
+			if getattr(o, 'windowControlID') == CONTROL_ID_ATTACHMENTS:
+				return True
+		return False		
+
+	def indexOfAttachment(self, obj):
+		for idx, o in enumerate(obj.parent.children):
+			if obj == o:
+				return idx
+		raise LookupError('Unable to find index of current item')
+
+	def currentFileWithPath(self):
+		obj = api.getFocusObject()
+		if not self.focusInAttachmentsList():
+			log.debug('Not in attachments list')
+			return None, None
+		index = self.indexOfAttachment(obj)
+		inspector = self.nativeOm.ActiveInspector()
+		tempDir = ''
+		if inspector is not None:
+			tempDir = tempfile.mkdtemp()
+			mailItem = inspector.CurrentItem
+			if mailItem.Attachments.Count > 0:
+				attachment = mailItem.Attachments.Item(index + 1)
+				tempPath = os.path.join(tempDir, attachment.FileName)
+				attachment.SaveAsFile(tempPath)
+				log.debug(f"{tempPath=}")
+				return tempPath, tempDir
+		return None, None


### PR DESCRIPTION
### Issue
When receiving inaccessible documents (PDF) in Outlook attachment, I have to copy them to Windows Explorer before I can OCR them.

### Solution
This PR implement OCR recognition on the selected attachment of an opened Outlook message.

### Testing
* Tested on Outlook 2016 on supported and unsupported files
* Tested in Windows Explorer that the feature still works

### Limitation
This probably only works with Outlook 2016 or higher, not with earlier versions of Office. I am not able to test with earlier versions.
