### PR TITLE
Fixes on French translation file

### DIFF
--- a/addon/doc/fr/readme.md
+++ b/addon/doc/fr/readme.md
@@ -1,12 +1,12 @@
 # Nao - NVDA Advanced OCR
 
-* Auteurs : Alessandro Albano, Davide De Carne, Simone Dal Maso
+* Auteurs : Alessandro Albano, Davide De Carne, Simone Dal Maso
 * Télécharger [version stable][1]
 * Compatibilité NVDA : 2019.3 et ultérieure
 
 Nao (NVDA Advanced OCR) est une extension qui améliore les capacités OCR standard fournies par NVDA sur les versions modernes de Windows.
 Alors que la commande standard de NVDA utilise l'OCR Windows pour reconnaître l'écran, NAO est capable d'effectuer l'OCR sur les fichiers enregistrés sur votre disque dur ou vos périphériques USB, ou dans les pièces jointes Microsoft Outlook.
-Utilisez NVDA-Maj-R pour reconnaître toutes sortes d'images et de PDF ! 
+Utilisez NVDA-Maj-R pour reconnaître toutes sortes d'images et de PDF ! 
 Placez simplement le focus/curseur sur le fichier que vous désirez, ne l'ouvrez pas, mais appuyez sur NVDA-Maj-r. 
 Le document sera reconnu et une simple fenêtre de texte apparaîtra, vous permettant de lire tout le contenu, de l'enregistrer, de rechercher du texte ou de copier du contenu dans le presse-papiers.
 Nao est capable de gérer également des pdf multipages, donc si vous avez un document inaccessible, ne vous inquiétez pas, Windows OCR pourra faire tout le travail.
@@ -14,23 +14,23 @@ Nao est capable de gérer également des pdf multipages, donc si vous avez un do
 ## Configuration requise
 L'extension fonctionne sur les systèmes Windows 10 et Windows 11, car ils ont des capacités OCR intégrées. 
 Nao est compatible à partir de la version 2019.3 de NVDA, donc n'utilisez pas une version plus ancienne du lecteur d'écran.
-Veuillez noter que Nao fonctionne avec l'explorateur Windows, sur le bureau ou avec les gestionnaires de fichiers Total Commander ou xplorer² ; n'utilisez pas d'autres logiciels comme 7zip ou Winrar , car ils ne sont pas pris en charge.
+Veuillez noter que Nao fonctionne avec l'explorateur Windows, sur le bureau ou avec les gestionnaires de fichiers Total Commander ou xplorer² ; n'utilisez pas d'autres logiciels comme 7zip ou Winrar , car ils ne sont pas pris en charge.
 Pour les pièces jointes aux e-mails, il fonctionne également avec Microsoft Outlook 2016 ou version ultérieure.
 
 ## Fonctionnalités et commandes
-* NVDA + Maj + R : reconnaît toutes sortes d'images et de pdf à partir du système de fichiers ou joints à un e-mail ;
-  * PgPréc / PgSuiv: déplace le curseur entre les pages réelles d'un document multipages.
-  * Ctrl + S : enregistre le document au format nao-document. Vous pouvez l'ouvrir à nouveau avec NVDA + Maj + R.
-  * P : annonce le numéro de page à la position du curseur, dans un document multipage.
-  * L : annonce le numéro de ligne à la position du curseur, compté sur la page courante.
+* NVDA + Maj + R : reconnaît toutes sortes d'images et de pdf à partir du système de fichiers ou joints à un e-mail ;
+  * PgPréc / PgSuiv : déplace le curseur entre les pages réelles d'un document multipages.
+  * Ctrl + S : enregistre le document au format nao-document. Vous pouvez l'ouvrir à nouveau avec NVDA + Maj + R.
+  * P : annonce le numéro de page à la position du curseur, dans un document multipage.
+  * L : annonce le numéro de ligne à la position du curseur, compté sur la page courante.
   * Maj + L : annonce le numéro de ligne à la position du curseur, compté sur l'ensemble du document.
-  * G : va directement sur une page déterminée.
-  * C : copie tout le texte dans le presse-papiers.
-  * S : enregistre une copie du document au format texte.
+  * G : va directement sur une page déterminée.
+  * C : copie tout le texte dans le presse-papiers.
+  * S : enregistre une copie du document au format texte.
   * F : recherche du texte et lit quelques mots avant et après la chaîne trouvée.
-* NVDA + Maj + Ctrl + R : prend une capture de la totalité de l'écran et effectue une reconnaissance.
+* NVDA + Maj + Ctrl + R : prend une capture de la totalité de l'écran et effectue une reconnaissance.
   * Veuillez noter que vous pouvez utiliser les commandes NVDA standard pour explorer la fenêtre et mettre le focus sur un élément. Par exemple, vous pouvez vous déplacer avec les touches fléchées et appuyer sur Entrée sur un bouton pour l'activer. Vous pouvez également amener la souris à votre position avec NVDA + PavNum/, puis cliquer avec les touches gauche/droite.
-* NVDA + Maj + Ctrl + W : prend une capture d'écran de la fenêtre courante et effectue une reconnaissance (mêmes fonctionnalités de navigation que la fonction de capture de la totalité de l'écran).
+* NVDA + Maj + Ctrl + W : prend une capture d'écran de la fenêtre courante et effectue une reconnaissance (mêmes fonctionnalités de navigation que la fonction de capture de la totalité de l'écran).
 
 Veuillez noter que vous pouvez personnaliser les raccourcis de Nao simplement à partir de la boîte de dialogue des gestes de commande de NVDA. Ouvrez le menu NVDA, allez dans les préférences, et à partir de ce sous-menu, sélectionnez la boîte de dialogue des gestes de commande. N'oubliez pas que cette fonctionnalité n'est pas globale, mais qu'elle ne fonctionne que là où Nao peut faire une reconnaissance de caractères. Ainsi, les gestes n'apparaîtront que si vous êtes sur le bureau, ou dans l'explorateur de fichiers, Total Commander ou Xplorer.
 
@@ -38,8 +38,8 @@ Vous pouvez également interrompre un long processus OCR en appuyant simplement 
 
 Vous trouverez un sous-menu nommé Nao, sous le menu NVDA - Outils. Il contient les éléments suivants :
 * Sélectionner un fichier : vous permet de sélectionner un fichier à traiter sans utiliser de raccourci.
-* Faites un don : c'est explicite, si le cœur vous en dit nous en serons très heureux !
-* Site Web Nao : vous amène à la page d'accueil de Nao.
+* Faites un don : c'est explicite, si le cœur vous en dit nous en serons très heureux !
+* Site Web Nao : vous amène à la page d'accueil de Nao.
 * Git : vous amène au code sourceò où vous pouvez le vérifier, effectuer un commit ou ouvrir un ticket.
 * Vérifier les mises à jour : interroge le serveur pour une nouvelle version de Nao.
 * Cache vide : si vous rencontrez des problèmes avec le module complémentaire, recevez des messages d'erreur ou trouvez-le lent, videz votre cache pour résoudre le problème.
@@ -49,7 +49,7 @@ Nao est absolument gratuit. Cependant, n'oubliez pas que cette extension est fai
 Nous apprécierions toute contribution que vous pourriez nous apporter !
 Si vous pensez que notre travail est bon et qu'il améliore votre vie, <a href="https://nvda-nao.org/donate">Envisagez de faire un don.</a>
 
-Vous souhaitez signaler un bug, proposer de nouvelles fonctionnalités, traduire l'extension dans votre langue ? Nous avons l'adresse e-mail qu'il vous faut ! Écrivez simplement à support@nvda-nao.org (a priori en anglais ou italien) et nous serons heureux de vous aider.
+Vous souhaitez signaler un bug, proposer de nouvelles fonctionnalités, traduire l'extension dans votre langue ? Nous avons l'adresse e-mail qu'il vous faut ! Écrivez simplement à support@nvda-nao.org (a priori en anglais ou italien) et nous serons heureux de vous aider.
 
 ## Historique
 ### 2025.1
@@ -99,13 +99,13 @@ Vous souhaitez signaler un bug, proposer de nouvelles fonctionnalités, traduire
 * L'OCR de pdf et des images sont présentés dans une nouvelle fenêtre de texte, avec quelques raccourcis clavier pour des opérations simples.
 * Prise en charge du gestionnaire de fichiers Xplorer.
 * Les raccourcis Nao sont personnalisables à partir de la boîte de dialogue Gestes d'entrée de NVDA.
-* Nao ne fonctionne que là où c'est possible, donc si vous êtes dans une fenêtre non prise en charge, le raccourci clavier sera ignoré par l'extension ; cela a résolu un problème important où les utilisateurs d'Excel et de Word ne pouvaient pas appuyer sur la touche NVDA-Maj-r, car elle était incorrectement interceptée par Nao.
+* Nao ne fonctionne que là où c'est possible, donc si vous êtes dans une fenêtre non prise en charge, le raccourci clavier sera ignoré par l'extension ; cela a résolu un problème important où les utilisateurs d'Excel et de Word ne pouvaient pas appuyer sur la touche NVDA-Maj-r, car elle était incorrectement interceptée par Nao.
 * Un long processus OCR peut être interrompu en appuyant simplement sur le bouton « Annuler » dans la fenêtre de la barre de progression.
 * Ajout de traductions en turc, russe, espagnol, chinois et français.
 * Les utilisateurs peuvent faire des dons au projet.
 * Correction d'un bug avec certains caractères dans le nom du fichier qui empêchait l'OCR de fonctionner correctement.
 ### 2021.1
-* Première version publique !
+* Première version publique !
 
 
 [1]: https://nvda-nao.org/download

--- a/addon/doc/fr/readme.md
+++ b/addon/doc/fr/readme.md
@@ -37,6 +37,7 @@ Veuillez noter que vous pouvez personnaliser les raccourcis de Nao simplement à
 Vous pouvez également interrompre un long processus OCR en appuyant simplement sur « Annuler » dans la fenêtre de la barre de progression ; cette fenêtre vous donne également des informations sur l'état de l'OCR, en mettant à jour les informations toutes les 5 secondes. Vous pouvez configurer comment recevoir les informations de la barre de progression avec la commande NVDA-u standard.
 
 Vous trouverez un sous-menu nommé Nao, sous le menu NVDA - Outils. Il contient les éléments suivants :
+
 * Sélectionner un fichier : vous permet de sélectionner un fichier à traiter sans utiliser de raccourci.
 * Faites un don : c'est explicite, si le cœur vous en dit nous en serons très heureux !
 * Site Web Nao : vous amène à la page d'accueil de Nao.

--- a/addon/doc/fr/readme.md
+++ b/addon/doc/fr/readme.md
@@ -14,7 +14,7 @@ Nao est capable de gérer également des pdf multipages, donc si vous avez un do
 ## Configuration requise
 L'extension fonctionne sur les systèmes Windows 10 et Windows 11, car ils ont des capacités OCR intégrées. 
 Nao est compatible à partir de la version 2019.3 de NVDA, donc n'utilisez pas une version plus ancienne du lecteur d'écran.
-Veuillez noter que Nao fonctionne avec l'explorateur Windows, sur le bureau ou avec les gestionnaires de fichiers Total Commander ou xplorer² ; n'utilisez pas d'autres logiciels comme 7zip ou Winrar , car ils ne sont pas pris en charge.
+Veuillez noter que Nao fonctionne avec l'explorateur Windows, sur le bureau ou avec les gestionnaires de fichiers Total Commander ou xplorer² ; n'utilisez pas d'autres logiciels comme 7zip ou Winrar, car ils ne sont pas pris en charge.
 Pour les pièces jointes aux e-mails, il fonctionne également avec Microsoft Outlook 2016 ou version ultérieure.
 
 ## Fonctionnalités et commandes

--- a/addon/doc/fr/readme.md
+++ b/addon/doc/fr/readme.md
@@ -6,8 +6,8 @@
 
 Nao (NVDA Advanced OCR) est une extension qui améliore les capacités OCR standard fournies par NVDA sur les versions modernes de Windows.
 Alors que la commande standard de NVDA utilise l'OCR Windows pour reconnaître l'écran, NAO est capable d'effectuer l'OCR sur les fichiers enregistrés sur votre disque dur ou vos périphériques USB, ou dans les pièces jointes Microsoft Outlook.
-Utilisez NVDA-Shift-R pour reconnaître toutes sortes d'images et de PDF ! 
-Placez simplement le focus/curseur sur le fichier que vous désirez, ne l'ouvrez pas, mais appuyez sur NVDA-Shift-r. 
+Utilisez NVDA-Maj-R pour reconnaître toutes sortes d'images et de PDF ! 
+Placez simplement le focus/curseur sur le fichier que vous désirez, ne l'ouvrez pas, mais appuyez sur NVDA-Maj-r. 
 Le document sera reconnu et une simple fenêtre de texte apparaîtra, vous permettant de lire tout le contenu, de l'enregistrer, de rechercher du texte ou de copier du contenu dans le presse-papiers.
 Nao est capable de gérer également des pdf multipages, donc si vous avez un document inaccessible, ne vous inquiétez pas, Windows OCR pourra faire tout le travail.
 
@@ -18,7 +18,7 @@ Veuillez noter que Nao fonctionne avec l'explorateur Windows, sur le bureau ou a
 Pour les pièces jointes aux e-mails, il fonctionne également avec Microsoft Outlook 2016 ou version ultérieure.
 
 ## Fonctionnalités et commandes
-* NVDA + Shift + R : reconnaît toutes sortes d'images et de pdf à partir du système de fichiers ;
+* NVDA + Maj + R : reconnaît toutes sortes d'images et de pdf à partir du système de fichiers ou joints à un e-mail ;
   * PgPréc / PgSuiv: déplace le curseur entre les pages réelles d'un document multipages.
   * Ctrl + S : enregistre le document au format nao-document. Vous pouvez l'ouvrir à nouveau avec NVDA + Maj + R.
   * P : annonce le numéro de page à la position du curseur, dans un document multipage.
@@ -53,20 +53,20 @@ Vous souhaitez signaler un bug, proposer de nouvelles fonctionnalités, traduire
 
 ## Historique
 ### 2025.1
-* Compatibilité NVDA version 2025.1
-* Implémenter la reconnaissance OCR sur la pièce jointe sélectionnée d'un message Outlook ouvert, à partir d'Outlook 2016 et au-delà
+* Compatibilité avec NVDA version 2025.1
+* Implémentation de la reconnaissance OCR sur la pièce jointe sélectionnée d'un message Outlook ouvert, à partir d'Outlook 2016 et au-delà
 * Ajout de la traduction finlandaise
 ### 2024.1
-* Compatibilité NVDA version 2024.1
+* Compatibilité avec NVDA version 2024.1
 ### 2023.1.1
 * Compatibilité avec NVDA version 2023.3 restaurée
-+* Un nouveau raccourci clavier NVDA + Ctrl + Maj + W prend une capture d'écran de la fenêtre courante et en effectue la reconnaissance
+* Un nouveau raccourci clavier NVDA + Ctrl + Maj + W prend une capture d'écran de la fenêtre courante et en effectue la reconnaissance
 * Ajout de la traductions en portugais brésilien
 * Correctif de sécurité sur les écrans sécurisés
 * Menu d'outils NAO supprimé sur les écrans sécurisés
 * Cache des documents supprimé sur les écrans sécurisés
 * Liens vers le site Web NAO et le référentiel Git ajoutés au menu des outils NAO
-+### 2023.1
+### 2023.1
 * Compatibilité avec NVDA version 2023.1
 ### 2022.1.3
 * Compatibilité avec NVDA version 2022.1
@@ -99,7 +99,7 @@ Vous souhaitez signaler un bug, proposer de nouvelles fonctionnalités, traduire
 * L'OCR de pdf et des images sont présentés dans une nouvelle fenêtre de texte, avec quelques raccourcis clavier pour des opérations simples.
 * Prise en charge du gestionnaire de fichiers Xplorer.
 * Les raccourcis Nao sont personnalisables à partir de la boîte de dialogue Gestes d'entrée de NVDA.
-* Nao ne fonctionne que là où c'est possible, donc si vous êtes dans une fenêtre non prise en charge, le raccourci clavier sera ignoré par l'extension ; cela a résolu un problème important où les utilisateurs d'Excel et de Word ne pouvaient pas appuyer sur la touche NVDA-Shift-r, car elle était incorrectement interceptée par Nao.
+* Nao ne fonctionne que là où c'est possible, donc si vous êtes dans une fenêtre non prise en charge, le raccourci clavier sera ignoré par l'extension ; cela a résolu un problème important où les utilisateurs d'Excel et de Word ne pouvaient pas appuyer sur la touche NVDA-Maj-r, car elle était incorrectement interceptée par Nao.
 * Un long processus OCR peut être interrompu en appuyant simplement sur le bouton « Annuler » dans la fenêtre de la barre de progression.
 * Ajout de traductions en turc, russe, espagnol, chinois et français.
 * Les utilisateurs peuvent faire des dons au projet.


### PR DESCRIPTION
Ciao a tutti!

Here are small fixes on the French readme file.
* Fixed formatting issues with `+` character left over
* Replaced "shift" by the French "maj".
* Harmonization of non-breaking spaces usage
* List formatting fix (add blank line before list): to be ported to English file in a separate work (I do not want to mix English doc edition with translated ones).

Please note that the English file is not up-to-date with respect to French or Italian file, mores specifically regarding the paragraph describing the "Nao" menu; this is not fixed in the current PR.
