### PR TITLE
Remove debug f-string syntax to keep compatibility with Python 3.7

### DIFF
--- a/addon/globalPlugins/nao/framework/storage/outlookHelper.py
+++ b/addon/globalPlugins/nao/framework/storage/outlookHelper.py
@@ -55,6 +55,6 @@ class OutlookHelper:
 				attachment = mailItem.Attachments.Item(index + 1)
 				tempPath = os.path.join(tempDir, attachment.FileName)
 				attachment.SaveAsFile(tempPath)
-				log.debug(f"{tempPath=}")
+				log.debug(f"tempPath={tempPath}")
 				return tempPath, tempDir
 		return None, None


### PR DESCRIPTION
### Issue
Although advertised to be compatible with NVDA 2019.3, Nao cannot start with this NVDA version.

An error occurs because I have used a debug f-string when implementing Outlook attachment support, i.e.:
`f"{tempPath=}"`

### Fix

Replace by a normal f-string which is compatible with any Python 3 version used by NVDA:
`f"tempPath={tempPath}"`

### Test
Tested with NVDA 2019.3
